### PR TITLE
handle -f alias for --file

### DIFF
--- a/conda
+++ b/conda
@@ -165,6 +165,9 @@ _comp_conda()
 
     __comp_conda_ensure_root 2>/dev/null
 
+    \local arg
+    _get_first_arg
+
     \local word_list cmd_str
     if [[ $cur == -* ]]; then
         # get the current list of commands as a string sans options
@@ -204,6 +207,11 @@ _comp_conda()
             build)
                 _filedir 'tar.bz2'              # package paths and directories
                 word_list='purge purge-all'     # special keywords
+                ;;
+            -f)
+                if [[ $arg == env ]]; then
+                     _filedir
+                fi
                 ;;
         esac
     fi

--- a/tests/test_conda.py
+++ b/tests/test_conda.py
@@ -48,6 +48,10 @@ class TestConda:
             'verify',
         ]
 
+    @pytest.mark.complete("conda clean -f ")
+    def test_clean_f(self, completion):
+        assert not completion
+
     @pytest.mark.complete("conda d")
     def test_top_level_partial_cmds(self, completion):
         assert completion
@@ -114,6 +118,16 @@ class TestConda:
             '--use-index-cache',
             '--verbose',
         ]
+
+    @pytest.mark.complete("conda env create -f ")
+    def test_env_create_f(self, completion):
+        assert completion
+        assert 'bashrc' in completion
+
+    @pytest.mark.complete("conda env update -f ")
+    def test_env_update_f(self, completion):
+        assert completion
+        assert 'bashrc' in completion
 
     @pytest.mark.complete("conda build ")
     def test_build_sub_comands(self, completion):


### PR DESCRIPTION
For now, the option `--file` autocomplete with filenames but not its alias `-f`. This is a simple fix to handle `-f`.